### PR TITLE
Issue-1117

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Newss/Create/CreateNewsHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Newss/Create/CreateNewsHandler.cs
@@ -49,6 +49,13 @@ namespace Streetcode.BLL.MediatR.Newss.Create
                 return Result.Fail(errorMsg);
             }
 
+            if (newNews.URL.Contains("/"))
+            {
+                string errorMsg = _stringLocalizerCannot["UrlContainsSlash"].Value;
+                _logger.LogError(request, errorMsg);
+                return Result.Fail(errorMsg);
+            }
+
             var entity = _repositoryWrapper.NewsRepository.Create(newNews);
             var resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
             if(resultIsSuccess)


### PR DESCRIPTION
## Summary of issue

[API] [Admin/News] There is no URL validation when creating news

Actual result
Received a response 200. The news is created. On the user side, when you click on this new, it redirects to a 404 page.

Expected result
Received a response 400. The news is not created. Does not allow to create news with the link that containing / .
