### PR TITLE
Feature/issue 1434

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Newss/Update/UpdateNewsHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Newss/Update/UpdateNewsHandler.cs
@@ -59,20 +59,20 @@ namespace Streetcode.BLL.MediatR.Newss.Update
                 return Result.Fail(errorMsg);
             }
 
-            var existingNewsByTitle = await _repositoryWrapper.NewsRepository.GetFirstOrDefaultAsync(predicate: n => n.Title == request.news.Title);
+            var existingNewsByTitle = await _repositoryWrapper.NewsRepository.GetFirstOrDefaultAsync(predicate: n => n.Title == request.news.Title && n.Id != request.news.Id);
             if (existingNewsByTitle != null)
             {
                 string errorMsg = "A news with the same title already exists.";
                 _logger.LogError(request, errorMsg);
-                return Result.Fail(errorMsg);
+                return Result.Fail(new Error(errorMsg));
             }
 
-            var existingNewsByText = await _repositoryWrapper.NewsRepository.GetSingleOrDefaultAsync(predicate: n => n.Text == request.news.Text);
+            var existingNewsByText = await _repositoryWrapper.NewsRepository.GetSingleOrDefaultAsync(predicate: n => n.Text == request.news.Text && n.Id != request.news.Id);
             if (existingNewsByText != null)
             {
                 string errorMsg = "A news with the same text already exists.";
                 _logger.LogError(request, errorMsg);
-                return Result.Fail(errorMsg);
+                return Result.Fail(new Error(errorMsg));
             }
 
             var response = _mapper.Map<NewsDTO>(news);


### PR DESCRIPTION
Issue:

When updating news we receive 400 error, the reason is that we have check for uniqueness of text & title. But it is triggered even if the only "same" title is of the news we are updating in the moment

Solve:

Added check for id of found news with the same title/text