### PR TITLE
Feature/issue 1434

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Newss/Update/UpdateNewsHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Newss/Update/UpdateNewsHandler.cs
@@ -75,21 +75,6 @@ namespace Streetcode.BLL.MediatR.Newss.Update
                 return Result.Fail(new Error(errorMsg));
             }
 
-            var response = _mapper.Map<NewsDTO>(news);
-
-            if (news.Image is not null)
-            {
-                response.Image.Base64 = _blobSevice.FindFileInStorageAsBase64(response.Image.BlobName);
-            }
-            else
-            {
-                var img = await _repositoryWrapper.ImageRepository.GetFirstOrDefaultAsync(x => x.Id == response.ImageId);
-                if (img != null)
-                {
-                    _repositoryWrapper.ImageRepository.Delete(img);
-                }
-            }
-
             _repositoryWrapper.NewsRepository.Update(news);
             var resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
 


### PR DESCRIPTION
dev
## Github

* [Main Github ticket](https://github.com/orgs/ita-social-projects/projects/21/views/10?sliceBy%5Bvalue%5D=Shossy&pane=issue&itemId=62170058)

## Summary of issue

Photos were deleted after news was updated

## Summary of change

Removed if statement which in its current state was only deleting each photo in the news during update