### PR TITLE
changed update-iteration.yml to move tasks to the next iteration

### DIFF
--- a/.github/workflows/update-iteration.yml
+++ b/.github/workflows/update-iteration.yml
@@ -19,4 +19,4 @@ jobs:
         iteration-field: Sprint
         iteration: last
         new-iteration: current
-        statuses: '✍Planned,🏗 In progress,👀PR,🔎In Q/A'
+        statuses: '✍Planned,🏗 In progress,👀PR,🔎In Q/A,🚫Blocked'

--- a/.github/workflows/update-iteration.yml
+++ b/.github/workflows/update-iteration.yml
@@ -19,4 +19,4 @@ jobs:
         iteration-field: Sprint
         iteration: last
         new-iteration: current
-        statuses: '✍Planned,🏗 In progress,👀PR'
+        statuses: '✍Planned,🏗 In progress,👀PR,🔎In Q/A'


### PR DESCRIPTION
dev
## JIRA

* [ticket-1662](https://github.com/ita-social-projects/StreetCode/issues/1662)


## Code reviewers

- [x] @Mikhail-Kolpakov

- [x] @mythter

- [x] @sashapanasiuk5

## Summary of issue

Modified the workflow to move all tasks to the next iteration except those with statuses  "Ready to release", and "Done".



## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
