### PR TITLE
GetTimelineItemById fixed to returtn correct timeline

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Timeline/TimelineItem/GetById/GetTimelineItemByIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Timeline/TimelineItem/GetById/GetTimelineItemByIdHandler.cs
@@ -29,7 +29,7 @@ public class GetTimelineItemByIdHandler : IRequestHandler<GetTimelineItemByIdQue
     {
         var timelineItem = await _repositoryWrapper.TimelineRepository
             .GetFirstOrDefaultAsync(
-                predicate: ti => true,
+                predicate: ti => ti.Id == request.Id,
                 include: ti => ti
                     .Include(til => til.HistoricalContextTimelines)
                         .ThenInclude(x => x.HistoricalContext)!);


### PR DESCRIPTION
* Ticket #1331


## Code reviewers

- [ ] @sashapanasiuk5
- [x] @Mikhail-Kolpakov 
- [ ] @ita-social-projects/734-08-streetcode 

## Summary of issue

GetTimelineItemById returns same value regardless of the passed id 

## Summary of change

GetTimelineItemById fixed to return the correct timeline according to the passed id

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
