### PR TITLE
added ToList() to ensure streetcodes are retrieved as a list

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetPageMainPage/GetPageOfStreetcodesMainPageHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetPageMainPage/GetPageOfStreetcodesMainPageHandler.cs
@@ -38,7 +38,7 @@ namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.GetPageMainPage
                 predicate: sc => sc.Status == DAL.Enums.StreetcodeStatus.Published,
                 include: src => src.Include(item => item.Text).Include(item => item.Images).ThenInclude(x => x.ImageDetails),
                 descendingSortKeySelector: sc => sc.CreatedAt)
-                .Entities;
+                .Entities.ToList();
 
             if (streetcodes is not null && streetcodes.Any())
             {


### PR DESCRIPTION
## Ticket info
Link to the corresponding GitHub board ticket: [#1726 ](https://github.com/orgs/ita-social-projects/projects/21/views/1?pane=issue&itemId=79090821)


## Description
This task involved fixing a bug where both black-and-white and colored images were being displayed on the main Streetcode display page, even though only black-and-white images should appear. The issue was resolved by ensuring that the list of streetcodes and their associated images were fully materialized using `.ToList()`, preventing deferred execution and ensuring that only the correct images (black-and-white) are displayed.


## Summary of change
Changes include:

- Applying `.ToList()` to the paginated streetcodes query to evaluate it immediately.
- Properly filtering the images to display only black-and-white ones before returning the results.

This fix ensures that only black-and-white images are shown on the main page, matching the expected behavior as seen in the catalog view.


## CHECK LIST
- [ ] CI passed
- [ ] Code coverage ≥ 95%
- [ ] PR is reviewed manually again (self-review)
- [ ] All reviewers have agreed to merge the PR
- [ ] PR meets all conventions and best practices