### PR TITLE
Sonar fixed in Jenkinsfile to check only the pull request

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,22 +98,28 @@ pipeline {
                 SONAR = credentials('sonar_token')
             }
             steps {
-                      sh 'sudo apt install openjdk-17-jdk openjdk-17-jre -y'
-                      sh """    echo "Sonar scan"
+                    sh 'sudo apt install openjdk-17-jdk openjdk-17-jre -y'
+                    withEnv([
+                        "PR_KEY=${env.CHANGE_ID}",
+                        "PR_BRANCH=${env.CHANGE_BRANCH}",
+                        "PR_BASE=${env.CHANGE_TARGET}",
+                    ]) {
+                        sh '''  echo "Sonar scan"
                                 dotnet sonarscanner begin \
                                 /k:"ita-social-projects_StreetCode" \
                                 /o:"ita-social-projects" \
-                                /d:sonar.token=${SONAR} \
+                                /d:sonar.token=$SONAR \
                                 /d:sonar.host.url="https://sonarcloud.io" \
                                 /d:sonar.cs.vscoveragexml.reportsPaths="**/coverage.xml" \
-                                /d:sonar.pullrequest.key=${env.CHANGE_ID} \
-                                /d:sonar.pullrequest.branch=${env.CHANGE_BRANCH} \
-                                /d:sonar.pullrequest.base=${env.CHANGE_TARGET}
-
+                                /d:sonar.pullrequest.key=$PR_KEY \
+                                /d:sonar.pullrequest.branch=$PR_BRANCH \
+                                /d:sonar.pullrequest.base=$PR_BASE
+                                
                                 dotnet build ./Streetcode/Streetcode.sln --configuration Release
                                 dotnet-coverage collect "dotnet test ./Streetcode/Streetcode.sln --configuration Release" -f xml -o "coverage.xml"
-                                dotnet sonarscanner end /d:sonar.token=${SONAR}
-                        """
+                                dotnet sonarscanner end /d:sonar.token=$SONAR_TOKEN
+                           '''
+                    }
             }
         }
         stage('Build image') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                                 
                                 dotnet build ./Streetcode/Streetcode.sln --configuration Release
                                 dotnet-coverage collect "dotnet test ./Streetcode/Streetcode.sln --configuration Release" -f xml -o "coverage.xml"
-                                dotnet sonarscanner end /d:sonar.token=$SONAR_TOKEN
+                                dotnet sonarscanner end /d:sonar.token=$SONAR
                            '''
                     }
             }


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#1661

## Summary of issue

Investigate and resolve the issue where SonarCloud in the Jenkins pipeline is not correctly posting the code quality report on pull requests.

## Summary of change

Added additional configuration to Sonar scan step in Jenkins pipeline to analyze only the pull request and send summary of analyzis to GitHub

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
