### PR TITLE
Jenkins condition added to Sonar step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,28 +98,45 @@ pipeline {
                 SONAR = credentials('sonar_token')
             }
             steps {
-                    sh 'sudo apt install openjdk-17-jdk openjdk-17-jre -y'
+                sh 'sudo apt install openjdk-17-jdk openjdk-17-jre -y'
+                script {
                     withEnv([
                         "PR_KEY=${env.CHANGE_ID}",
                         "PR_BRANCH=${env.CHANGE_BRANCH}",
                         "PR_BASE=${env.CHANGE_TARGET}",
                     ]) {
-                        sh '''  echo "Sonar scan"
-                                dotnet sonarscanner begin \
-                                /k:"ita-social-projects_StreetCode" \
-                                /o:"ita-social-projects" \
-                                /d:sonar.token=$SONAR \
-                                /d:sonar.host.url="https://sonarcloud.io" \
-                                /d:sonar.cs.vscoveragexml.reportsPaths="**/coverage.xml" \
-                                /d:sonar.pullrequest.key=$PR_KEY \
-                                /d:sonar.pullrequest.branch=$PR_BRANCH \
-                                /d:sonar.pullrequest.base=$PR_BASE
-                                
-                                dotnet build ./Streetcode/Streetcode.sln --configuration Release
-                                dotnet-coverage collect "dotnet test ./Streetcode/Streetcode.sln --configuration Release" -f xml -o "coverage.xml"
-                                dotnet sonarscanner end /d:sonar.token=$SONAR
-                           '''
+                        if (env.PR_KEY != "null") {                        
+                            sh  ''' echo "Sonar scan"
+                                    dotnet sonarscanner begin \
+                                    /k:"ita-social-projects_StreetCode" \
+                                    /o:"ita-social-projects" \
+                                    /d:sonar.token=$SONAR \
+                                    /d:sonar.host.url="https://sonarcloud.io" \
+                                    /d:sonar.cs.vscoveragexml.reportsPaths="**/coverage.xml" \
+                                    /d:sonar.pullrequest.key=$PR_KEY \
+                                    /d:sonar.pullrequest.branch=$PR_BRANCH \
+                                    /d:sonar.pullrequest.base=$PR_BASE
+
+                                    dotnet build ./Streetcode/Streetcode.sln --configuration Release
+                                    dotnet-coverage collect "dotnet test ./Streetcode/Streetcode.sln --configuration Release" -f xml -o "coverage.xml"
+                                    dotnet sonarscanner end /d:sonar.token=$SONAR
+                            '''
+                        } else {
+                            sh  ''' echo "Sonar scan"
+                                    dotnet sonarscanner begin \
+                                    /k:"ita-social-projects_StreetCode" \
+                                    /o:"ita-social-projects" \
+                                    /d:sonar.token=$SONAR \
+                                    /d:sonar.host.url="https://sonarcloud.io" \
+                                    /d:sonar.cs.vscoveragexml.reportsPaths="**/coverage.xml" \
+
+                                    dotnet build ./Streetcode/Streetcode.sln --configuration Release
+                                    dotnet-coverage collect "dotnet test ./Streetcode/Streetcode.sln --configuration Release" -f xml -o "coverage.xml"
+                                    dotnet sonarscanner end /d:sonar.token=$SONAR
+                            '''
+                        }
                     }
+                }
             }
         }
         stage('Build image') {


### PR DESCRIPTION
* Ticket ita-social-projects/StreetCode#1661

## Summary of issue

Investigate and resolve the issue where SonarCloud in the Jenkins pipeline is not correctly posting the code quality report on pull requests.

## Summary of change

Added additional configuration to Sonar scan step in Jenkins pipeline to analyze only the pull request and send summary of analyzis to GitHub. If pipeline triggerred after merge the full scan starts.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
