### PR TITLE
Feature/issue 1147

### DIFF
--- a/Streetcode/Streetcode.BLL/Validators/Common/ValidationExtentions.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Common/ValidationExtentions.cs
@@ -1,6 +1,6 @@
 ﻿using FluentValidation;
-using FluentValidation.Validators;
 using Streetcode.DAL.Enums;
+using Streetcode.DAL.Repositories.Interfaces.Base;
 
 namespace Streetcode.BLL.Validators.Common;
 
@@ -77,5 +77,12 @@ public static class ValidationExtentions
         var result = values[0];
         result += string.Concat(values.Skip(1).Select(e => $", {e}"));
         return result;
+    }
+
+    public static async Task<bool> HasExistingImage(IRepositoryWrapper repositoryWrapper, int imageId, CancellationToken token)
+    {
+        var image = await repositoryWrapper.ImageRepository
+            .GetFirstOrDefaultAsync(a => a.Id == imageId);
+        return image != null;
     }
 }

--- a/Streetcode/Streetcode.BLL/Validators/SourceLinkCategory/BaseCategoryValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/SourceLinkCategory/BaseCategoryValidator.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Localization;
 using Streetcode.BLL.DTO.Sources;
 using Streetcode.BLL.SharedResource;
+using Streetcode.BLL.Validators.Common;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 
 namespace Streetcode.BLL.Validators.SourceLinkCategory;
@@ -18,13 +19,6 @@ public class BaseCategoryValidator : AbstractValidator<SourceLinkCreateUpdateCat
             .MaximumLength(MaxCategoryLength).WithMessage(localizer["MaxLength", fieldLocalizer["Title"], MaxCategoryLength]);
 
         RuleFor(x => x.ImageId)
-            .MustAsync(HasExistingImage).WithMessage(x => localizer["ImageDoesntExist", x.ImageId]);
-    }
-
-    public async Task<bool> HasExistingImage(int imageId, CancellationToken token)
-    {
-        var image = await _repositoryWrapper.ImageRepository
-            .GetFirstOrDefaultAsync(a => a.Id == imageId);
-        return image != null;
+            .MustAsync((imageId, token) => ValidationExtentions.HasExistingImage(_repositoryWrapper, imageId, token)).WithMessage(x => localizer["ImageDoesntExist", x.ImageId]);
     }
 }

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/CreateStreetcodeValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/CreateStreetcodeValidator.cs
@@ -50,14 +50,9 @@ public class CreateStreetcodeValidator : AbstractValidator<CreateStreetcodeComma
         RuleFor(x => x.Streetcode.ImagesIds)
             .NotEmpty()
             .WithMessage(localizer["CannotBeEmpty", fieldLocalizer["Images"]]);
-            
-            
         RuleForEach(x => x.Streetcode.ImagesIds)
             .MustAsync((imageId, token) => ValidationExtentions.HasExistingImage(_repositoryWrapper, imageId, token))
             .WithMessage((dto, imgId) => localizer["ImageDoesntExist", imgId]);
-        
-
-        
 
         RuleForEach(c => c.Streetcode.Tags).SetValidator(tagValidator);
         RuleForEach(c => c.Streetcode.Subtitles).SetValidator(baseSubtitleValidator);

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/CreateStreetcodeValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/CreateStreetcodeValidator.cs
@@ -48,11 +48,14 @@ public class CreateStreetcodeValidator : AbstractValidator<CreateStreetcodeComma
             .SetValidator(baseTextValidator);
 
         RuleFor(x => x.Streetcode.ImagesIds)
-            .NotEmpty().WithMessage(localizer["CannotBeEmpty", fieldLocalizer["Images"]])
-            .ForEach(img =>
-            {
-                img.MustAsync((imageId, token) => ValidationExtentions.HasExistingImage(_repositoryWrapper, imageId, token)).WithMessage((dto, imgId) => localizer["ImageDoesntExist", imgId]);
-            });
+            .NotEmpty()
+            .WithMessage(localizer["CannotBeEmpty", fieldLocalizer["Images"]]);
+            
+            
+        RuleForEach(x => x.Streetcode.ImagesIds)
+            .MustAsync((imageId, token) => ValidationExtentions.HasExistingImage(_repositoryWrapper, imageId, token))
+            .WithMessage((dto, imgId) => localizer["ImageDoesntExist", imgId]);
+        
 
         
 

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/CreateStreetcodeValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/CreateStreetcodeValidator.cs
@@ -48,7 +48,13 @@ public class CreateStreetcodeValidator : AbstractValidator<CreateStreetcodeComma
             .SetValidator(baseTextValidator);
 
         RuleFor(x => x.Streetcode.ImagesIds)
-            .NotEmpty().WithMessage(localizer["CannotBeEmpty", fieldLocalizer["Images"]]);
+            .NotEmpty().WithMessage(localizer["CannotBeEmpty", fieldLocalizer["Images"]])
+            .ForEach(img =>
+            {
+                img.MustAsync((imageId, token) => ValidationExtentions.HasExistingImage(_repositoryWrapper, imageId, token)).WithMessage((dto, imgId) => localizer["ImageDoesntExist", imgId]);
+            });
+
+        
 
         RuleForEach(c => c.Streetcode.Tags).SetValidator(tagValidator);
         RuleForEach(c => c.Streetcode.Subtitles).SetValidator(baseSubtitleValidator);

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/ImageDetails/ImageDetailsValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/ImageDetails/ImageDetailsValidator.cs
@@ -27,7 +27,6 @@ public class ImageDetailsValidator : AbstractValidator<ImageDetailsDto>
 
         RuleFor(dto => dto)
             .MustAsync(BeUniqueImageIdInImageDetails).WithMessage(x => localizer["MustBeUnique", fieldLocalizer["ImageId"]]);
-        
         RuleFor(dto => dto.ImageId)
             .MustAsync((imageId, token) => ValidationExtentions.HasExistingImage(_repositoryWrapper, imageId, token)).WithMessage(x => localizer["ImageDoesntExist", x.ImageId]);
     }

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/ImageDetails/ImageDetailsValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/ImageDetails/ImageDetailsValidator.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using Microsoft.Extensions.Localization;
 using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.SharedResource;
+using Streetcode.BLL.Validators.Common;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 
 namespace Streetcode.BLL.Validators.Streetcode.ImageDetails;
@@ -26,6 +27,9 @@ public class ImageDetailsValidator : AbstractValidator<ImageDetailsDto>
 
         RuleFor(dto => dto)
             .MustAsync(BeUniqueImageIdInImageDetails).WithMessage(x => localizer["MustBeUnique", fieldLocalizer["ImageId"]]);
+        
+        RuleFor(dto => dto.ImageId)
+            .MustAsync((imageId, token) => ValidationExtentions.HasExistingImage(_repositoryWrapper, imageId, token)).WithMessage(x => localizer["ImageDoesntExist", x.ImageId]);
     }
 
     private async Task<bool> BeUniqueImageIdInImageDetails(ImageDetailsDto imageDetails, CancellationToken cancellationToken)


### PR DESCRIPTION

## Github
* [Github ticket](https://github.com/ita-social-projects/StreetCode/issues/1147)


## Summary of issue

When making a request for a streetcode, an exception related to a foreign key occurred if the imageIds field or imageDetails:imageId did not exist in the database.

## Summary of change

New validation rules have been added to check if image IDs exist. These rules prevent the exception from occurring.

## Testing approach

New unit tests have been added for the validation rules.


