### PR TITLE
Removed validation rule for HistoricalContext so it could be null.

### DIFF
--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/Timeline/TimelineItemValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/Timeline/TimelineItemValidator.cs
@@ -31,8 +31,7 @@ public class TimelineItemValidator : AbstractValidator<TimelineItemCreateUpdateD
 
         RuleFor(dto => dto.ModelState)
             .IsInEnum().WithMessage(localizer["Invalid", fieldLocalizer["ModelState"]]);
-        RuleFor(dto => dto.HistoricalContexts)
-            .NotEmpty().WithMessage(localizer["CannotBeEmpty", fieldLocalizer["HistoricalContexts"]]);
+
         RuleForEach(dto => dto.HistoricalContexts)
             .SetValidator(historicalContextValidator);
     }


### PR DESCRIPTION
* [Main Github ticket](https://github.com/ita-social-projects/StreetCode/issues/1817)

## Summary of issue

Response "Bad Request" while trying to create new streetcode with timeline without historical context (non-mandatory field).

## Summary of change

Fixed validation rule for historical context in the timeline item of streetcode.
