### PR TITLE
edited streetcodeCreate to accept numeric array of partners

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/Create/StreetcodeCreateDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/Create/StreetcodeCreateDTO.cs
@@ -23,7 +23,7 @@ namespace Streetcode.BLL.DTO.Streetcode.Create
         public IEnumerable<StreetcodeFactCreateDTO> Facts { get; set; } = null!;
         public IEnumerable<VideoCreateDTO>? Videos { get; set; } = null!; // video is only one
         public IEnumerable<RelatedFigureShortDTO> RelatedFigures { get; set; } = null!;
-        public IEnumerable<PartnerShortDTO> Partners { get; set; } = null!;
+        public IEnumerable<int> Partners { get; set; } = null!;
         public IEnumerable<CategoryContentCreateDTO> StreetcodeCategoryContents { get; set; } = null!;
         public IEnumerable<StreetcodeCoordinateDTO> Coordinates { get; set; } = null!;
         public IEnumerable<StatisticRecordDTO> StatisticRecords { get; set; } = null!;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
@@ -325,12 +325,12 @@ public class CreateStreetcodeHandler : IRequestHandler<CreateStreetcodeCommand, 
         streetcode.TimelineItems.AddRange(newTimelines);
     }
 
-    private async Task AddPartners(StreetcodeContent streetcode, IEnumerable<PartnerShortDTO> partners)
+    private async Task AddPartners(StreetcodeContent streetcode, IEnumerable<int> partners)
     {
-        var partnersToCreate = partners.Select(partner => new StreetcodePartner
+        var partnersToCreate = partners.Select(partnerId => new StreetcodePartner
         {
             StreetcodeId = streetcode.Id,
-            PartnerId = partner.Id
+            PartnerId = partnerId
         })
           .ToList();
         await _repositoryWrapper.PartnerStreetcodeRepository.CreateRangeAsync(partnersToCreate);

--- a/Streetcode/Streetcode.XIntegrationTest/ControllerTests/Utils/BeforeAndAfterTestAtribute/Streetcode/ExtractCreateTestStreetcodeAttribute.cs
+++ b/Streetcode/Streetcode.XIntegrationTest/ControllerTests/Utils/BeforeAndAfterTestAtribute/Streetcode/ExtractCreateTestStreetcodeAttribute.cs
@@ -58,7 +58,7 @@ namespace Streetcode.XIntegrationTest.ControllerTests.Utils.BeforeAndAfterTestAt
                 Subtitles = new List<SubtitleCreateDTO>(),
                 Facts = new List<StreetcodeFactCreateDTO>(),
                 Videos = new List<VideoCreateDTO>(),
-                Partners = new List<PartnerShortDTO>(),
+                Partners = new List<int>(),
                 Arts = new List<ArtCreateUpdateDTO>(),
                 StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>(),
                 StatisticRecords = new List<StatisticRecordDTO>(),


### PR DESCRIPTION
## GitHub

* [Main GitHub ticket](https://github.com/ita-social-projects/StreetCode/issues/1330)

## Summary of issue

When creating streetcode the response returns a '400 Bad Request' status when sending numeric array of partners ( e.g. "partners": [31, 32, 41], ).

## Summary of change

Changed CreateStreetcode.Handler to manipulate numeric array of partners rather than PartnersShortDTO array.
