### PR TITLE
Feature/issue 1382

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/Сreate/CreateRelatedFigureHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/Сreate/CreateRelatedFigureHandler.cs
@@ -48,6 +48,17 @@ public class CreateRelatedFigureHandler : IRequestHandler<CreateRelatedFigureCom
             return Result.Fail(new Error(errorMsg));
         }
 
+        var existingRelation = await _repositoryWrapper.RelatedFigureRepository.GetFirstOrDefaultAsync(rel =>
+            (rel.ObserverId == request.ObserverId && rel.TargetId == request.TargetId) ||
+            (rel.ObserverId == request.TargetId && rel.TargetId == request.ObserverId));
+
+        if (existingRelation is not null)
+        {
+            string errorMsg = _stringLocalizerFailed["FailedToCreateRelation"].Value;
+            _logger.LogError(request, errorMsg);
+            return Result.Fail(new Error(errorMsg));
+        }
+
         var relation = new DAL.Entities.Streetcode.RelatedFigure
         {
             ObserverId = observerEntity.Id,

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/Сreate/CreateRelatedFigureHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/Сreate/CreateRelatedFigureHandler.cs
@@ -54,7 +54,7 @@ public class CreateRelatedFigureHandler : IRequestHandler<CreateRelatedFigureCom
 
         if (existingRelation is not null)
         {
-            string errorMsg = _stringLocalizerFailed["FailedToCreateRelation"].Value;
+            string errorMsg = _stringLocalizerFailed["TheStreetcodesAreAlreadyLinked"].Value;
             _logger.LogError(request, errorMsg);
             return Result.Fail(new Error(errorMsg));
         }

--- a/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToCreateSharedResource.en-US.resx
+++ b/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToCreateSharedResource.en-US.resx
@@ -153,4 +153,7 @@
   <data name="FailedToMapCreatedTerm" xml:space="preserve">
     <value>Failed to map created term</value>
   </data>
+  <data name="TheStreetcodesAreAlreadyLinked" xml:space="preserve">
+    <value>The streetcodes are already linked</value>
+  </data>
 </root>

--- a/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToCreateSharedResource.uk-UA.resx
+++ b/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToCreateSharedResource.uk-UA.resx
@@ -147,4 +147,13 @@
   <data name="FailedToCreateTerm" xml:space="preserve">
     <value>Не вдалося створити термін</value>
   </data>
+  <data name="TheStreetcodesAreAlreadyLinked" xml:space="preserve">
+    <value>Стріткоди вже пов'язані</value>
+  </data>
+  <data name="FailedToMapCreatedTerm" xml:space="preserve">
+    <value>Не вдалося зіставити створений термін</value>
+  </data>
+  <data name="FailedToMapCreatedTeamLink" xml:space="preserve">
+    <value>Не вдалося зіставити створене посилання команди</value>
+  </data>
 </root>

--- a/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
+++ b/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
@@ -204,7 +204,6 @@
       <DependentUpon>SharedResource.NoSharedResource.uk-UA.resx</DependentUpon>
     </Compile>
     <Compile Remove="ByteArrayFormatter.cs" />
-    <Compile Remove="Resources\SharedResource.FailedToCreateSharedResource.en-US.Designer.cs" />
 
     <Compile Update="Resources\SharedResource.FailedToValidateSharedResource.en-US.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -229,7 +228,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Remove="Resources\SharedResource.FailedToCreateSharedResource.en-US.resx" />
+    <EmbeddedResource Update="Resources\SharedResource.FailedToCreateSharedResource.en-US.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>SharedResource.FailedToCreateSharedResource.en-US.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Update="Resources\SharedResource.FailedToValidateSharedResource.en-US.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>SharedResource.FailedToValidateSharedResource.en-US.Designer.cs</LastGenOutput>


### PR DESCRIPTION
dev
## JIRA

* [#1382]

## Summary of issue

There was no check to determine if a relation already exists between IDs. This caused an error with duplicate keys when attempting to insert into the table (resulting in a 500 error from the API). Additionally, reversing the order of the IDs allowed the insert to succeed and returned a 200 status.

## Summary of change

Added a check for existing relations and included error messages in shared resource files.
