### PR TITLE
Feature/issue-1766

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/News/CreateUpdateNewsDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/News/CreateUpdateNewsDTO.cs
@@ -12,10 +12,12 @@ public abstract class CreateUpdateNewsDTO
     [Required(AllowEmptyStrings = false)]
     [StringLength(15000, ErrorMessage = "Max Length is 15000")]
     public string Text { get; set; } = null!;
+    [Required]
     public int ImageId { get; set; }
 
     [Required(AllowEmptyStrings = false)]
     [StringLength(200, ErrorMessage = "Max Length is 200")]
     public string URL { get; set; } = null!;
+    [Required]
     public DateTime CreationDate { get; set; }
 }

--- a/Streetcode/Streetcode.BLL/Validators/News/BaseNewsValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/News/BaseNewsValidator.cs
@@ -10,6 +10,7 @@ namespace Streetcode.BLL.Validators.News;
 public class BaseNewsValidator : AbstractValidator<CreateUpdateNewsDTO>
 {
     public const int TitleMaxLength = 100;
+    public const int TextMaxLength = 15000;
     public const int UrlMaxLength = 200;
     private const int ImageIdMinValue = 0;
     private readonly IRepositoryWrapper _repositoryWrapper;
@@ -25,9 +26,11 @@ public class BaseNewsValidator : AbstractValidator<CreateUpdateNewsDTO>
                 .MaximumLength(TitleMaxLength).WithMessage(x => localizer["MaxLength", fieldLocalizer["Title"], TitleMaxLength]);
 
         RuleFor(x => x.Text)
-            .NotEmpty().WithMessage(localizer["CannotBeEmpty", fieldLocalizer["Text"]]);
+            .NotEmpty().WithMessage(localizer["CannotBeEmpty", fieldLocalizer["Text"]])
+            .MaximumLength(TextMaxLength).WithMessage(x => localizer["MaxLength", fieldLocalizer["Text"], TextMaxLength]);
 
         RuleFor(x => x.ImageId)
+                .NotEmpty().WithMessage(localizer["CannotBeEmpty", fieldLocalizer["ImageId"]])
                 .GreaterThan(ImageIdMinValue).WithMessage(x => localizer["Invalid", fieldLocalizer["ImageId"]])
                 .MustAsync(BeExistingImageId).WithMessage(x => localizer["ImageDoesntExist", x.ImageId]);
 


### PR DESCRIPTION
## Github ticket
#1766

## Summary of issue
The Swagger documentation for the NewsCreateDTO endpoint /api/News/Create does not align with the functional requirements. The mandatory fields imageId and creationDate are not marked as required in the Swagger schema, causing confusion and potentially incorrect API usage.

## Summary of change
- Updated the NewsCreateDTO definition to correctly mark the fields imageId and creationDate as mandatory.
- Adjusted the Swagger annotations in the DTO class to reflect the correct schema.
- Identified and resolved inconsistencies in BaseNewsValidator related to the TextMaxLength constraint, ensuring it is correctly enforced.