### PR TITLE
Feature/issue-1924

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/AdditionalContent/Tag/GetByStreetcodeId/GetTagByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/AdditionalContent/Tag/GetByStreetcodeId/GetTagByStreetcodeIdHandler.cs
@@ -31,7 +31,7 @@ public class GetTagByStreetcodeIdHandler : IRequestHandler<GetTagByStreetcodeIdQ
     {
         if (request.StreetcodeId < 1)
         {
-            string errorMsg = _stringLocalizerCannotFind["HistorycodeIdCannotBeLessThan1", request.StreetcodeId].Value;
+            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyTagByTheStreetcodeId", request.StreetcodeId].Value;
             _logger.LogError(request, errorMsg);
             return Result.Fail(new Error(errorMsg));
         }

--- a/Streetcode/Streetcode.BLL/MediatR/AdditionalContent/Tag/GetByStreetcodeId/GetTagByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/AdditionalContent/Tag/GetByStreetcodeId/GetTagByStreetcodeIdHandler.cs
@@ -4,7 +4,9 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using Streetcode.BLL.DTO.AdditionalContent.Tag;
+using Streetcode.BLL.DTO.Toponyms;
 using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.ResultVariations;
 using Streetcode.BLL.SharedResource;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 
@@ -27,16 +29,23 @@ public class GetTagByStreetcodeIdHandler : IRequestHandler<GetTagByStreetcodeIdQ
 
     public async Task<Result<IEnumerable<StreetcodeTagDTO>>> Handle(GetTagByStreetcodeIdQuery request, CancellationToken cancellationToken)
     {
+        if (request.StreetcodeId < 1)
+        {
+            string errorMsg = _stringLocalizerCannotFind["HistorycodeIdCannotBeLessThan1", request.StreetcodeId].Value;
+            _logger.LogError(request, errorMsg);
+            return Result.Fail(new Error(errorMsg));
+        }
+
         var tagIndexed = await _repositoryWrapper.StreetcodeTagIndexRepository
             .GetAllAsync(
                 t => t.StreetcodeId == request.StreetcodeId,
                 include: q => q.Include(t => t.Tag!));
 
-        if (!tagIndexed.Any() || request.StreetcodeId < 1)
+        if (!tagIndexed.Any())
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyTagByTheStreetcodeId", request.StreetcodeId].Value;
-            _logger.LogError(request, errorMsg);
-            return Result.Fail(new Error(errorMsg));
+            string message = "Returning empty enumerable of tags";
+            _logger.LogInformation(message);
+            return Result.Ok(Enumerable.Empty<StreetcodeTagDTO>());
         }
 
         return Result.Ok(_mapper.Map<IEnumerable<StreetcodeTagDTO>>(tagIndexed.OrderBy(ti => ti.Index)));

--- a/Streetcode/Streetcode.BLL/MediatR/Media/Art/GetByStreetcodeId/GetArtsByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Media/Art/GetByStreetcodeId/GetArtsByStreetcodeIdHandler.cs
@@ -37,7 +37,7 @@ namespace Streetcode.BLL.MediatR.Media.Art.GetByStreetcodeId
         {
             if (request.StreetcodeId < 1)
             {
-                string errorMsg = _stringLocalizerCannotFind["HistorycodeIdCannotBeLessThan1", request.StreetcodeId].Value;
+                string errorMsg = _stringLocalizerCannotFind["CannotFindAnyArtByTheStreetcodeId", request.StreetcodeId].Value;
                 _logger.LogError(request, errorMsg);
                 return Result.Fail(new Error(errorMsg));
             }

--- a/Streetcode/Streetcode.BLL/MediatR/Partners/GetByStreetcodeId/GetPartnersByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Partners/GetByStreetcodeId/GetPartnersByStreetcodeIdHandler.cs
@@ -32,7 +32,7 @@ public class GetPartnersByStreetcodeIdHandler : IRequestHandler<GetPartnersByStr
 
         if (streetcode is null)
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyStreetcodeWithCorrespondingStreetcodeId", request.StreetcodeId].Value;
+            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyHistorycodesWithCorrespondingHistorycodeId", request.StreetcodeId].Value;
             _logger.LogError(request, errorMsg);
             return Result.Fail(new Error(errorMsg));
         }
@@ -44,11 +44,11 @@ public class GetPartnersByStreetcodeIdHandler : IRequestHandler<GetPartnersByStr
 
         if (!partners.Any())
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindPartnersByStreetcodeId", request.StreetcodeId].Value;
-            _logger.LogError(request, errorMsg);
-            return Result.Fail(new Error(errorMsg));
+            string message = "Returning empty enumerable of partners";
+            _logger.LogInformation(message);
+            return Result.Ok(Enumerable.Empty<PartnerDTO>());
         }
 
-        return Result.Ok(value: _mapper.Map<IEnumerable<PartnerDTO>>(partners));
+        return Result.Ok(_mapper.Map<IEnumerable<PartnerDTO>>(partners));
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Partners/GetByStreetcodeId/GetPartnersByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Partners/GetByStreetcodeId/GetPartnersByStreetcodeIdHandler.cs
@@ -32,7 +32,7 @@ public class GetPartnersByStreetcodeIdHandler : IRequestHandler<GetPartnersByStr
 
         if (streetcode is null)
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyHistorycodesWithCorrespondingHistorycodeId", request.StreetcodeId].Value;
+            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyStreetcodeWithCorrespondingStreetcodeId", request.StreetcodeId].Value;
             _logger.LogError(request, errorMsg);
             return Result.Fail(new Error(errorMsg));
         }

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/GetCategoriesByStreetcodeId/GetCategoriesByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/GetCategoriesByStreetcodeId/GetCategoriesByStreetcodeIdHandler.cs
@@ -38,9 +38,9 @@ public class GetCategoriesByStreetcodeIdHandler : IRequestHandler<GetCategoriesB
 
         if (!srcCategories.Any())
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnySourceCategoryWithTheStreetcodeId", request.StreetcodeId].Value;
-            _logger.LogError(request, errorMsg);
-            return Result.Fail(new Error(errorMsg));
+            string message = "Returning empty enumerable of categories";
+            _logger.LogInformation(message);
+            return Result.Ok(Enumerable.Empty<SourceLinkCategoryDTO>());
         }
 
         var mappedSrcCategories = _mapper.Map<IEnumerable<SourceLinkCategoryDTO>>(srcCategories);

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/GetByStreetcodeId/GetFactByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/GetByStreetcodeId/GetFactByStreetcodeIdHandler.cs
@@ -26,16 +26,16 @@ public class GetFactByStreetcodeIdHandler : IRequestHandler<GetFactByStreetcodeI
 
     public async Task<Result<IEnumerable<FactDto>>> Handle(GetFactByStreetcodeIdQuery request, CancellationToken cancellationToken)
     {
-        var fact = await _repositoryWrapper.FactRepository
+        var facts = await _repositoryWrapper.FactRepository
             .GetAllAsync(f => f.StreetcodeId == request.StreetcodeId);
 
-        if (fact is null)
+        if (!facts.Any())
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyFactByTheStreetcodeId", request.StreetcodeId].Value;
-            _logger.LogError(request, errorMsg);
-            return Result.Fail(new Error(errorMsg));
+            string message = "Returning empty enumerable of facts";
+            _logger.LogInformation(message);
+            return Result.Ok(Enumerable.Empty<FactDto>());
         }
 
-        return Result.Ok(_mapper.Map<IEnumerable<FactDto>>(fact.OrderBy(f => f.Index)));
+        return Result.Ok(_mapper.Map<IEnumerable<FactDto>>(facts.OrderBy(f => f.Index)));
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/GetByStreetcodeId/GetRelatedFiguresByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/GetByStreetcodeId/GetRelatedFiguresByStreetcodeIdHandler.cs
@@ -47,7 +47,7 @@ public class GetRelatedFiguresByStreetcodeIdHandler : IRequestHandler<GetRelated
 
         if (!relatedFigures.Any())
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyHistorycodesCorrespondingToRelatedFiguresIds", request.StreetcodeId].Value;
+            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyRelatedFiguresByStreetcodeId", request.StreetcodeId].Value;
             _logger.LogError(request, errorMsg);
 
             return Result.Fail(new Error(errorMsg));

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/GetByStreetcodeId/GetRelatedFiguresByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedFigure/GetByStreetcodeId/GetRelatedFiguresByStreetcodeIdHandler.cs
@@ -35,9 +35,9 @@ public class GetRelatedFiguresByStreetcodeIdHandler : IRequestHandler<GetRelated
 
         if (!relatedFigureIds.Any())
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyRelatedFiguresByStreetcodeId", request.StreetcodeId].Value;
-            _logger.LogError(request, errorMsg);
-            return Result.Fail(new Error(errorMsg));
+            string message = "Returning empty enumerable of related figures";
+            _logger.LogInformation(message);
+            return Result.Ok(Enumerable.Empty<RelatedFigureDTO>());
         }
 
         var relatedFigures = await _repositoryWrapper.StreetcodeRepository.GetAllAsync(
@@ -47,10 +47,10 @@ public class GetRelatedFiguresByStreetcodeIdHandler : IRequestHandler<GetRelated
 
         if (!relatedFigures.Any())
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyRelatedFiguresByStreetcodeId", request.StreetcodeId].Value;
+            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyHistorycodesCorrespondingToRelatedFiguresIds", request.StreetcodeId].Value;
             _logger.LogError(request, errorMsg);
 
-            return Result.Ok<IEnumerable<RelatedFigureDTO>?>(null);
+            return Result.Fail(new Error(errorMsg));
         }
 
         foreach(StreetcodeContent streetcode in relatedFigures)

--- a/Streetcode/Streetcode.BLL/MediatR/Timeline/TimelineItem/GetByStreetcodeId/GetTimelineItemsByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Timeline/TimelineItem/GetByStreetcodeId/GetTimelineItemsByStreetcodeIdHandler.cs
@@ -36,9 +36,9 @@ public class GetTimelineItemsByStreetcodeIdHandler : IRequestHandler<GetTimeline
 
         if (!timelineItems.Any())
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyTimelineItemByTheStreetcodeId", request.StreetcodeId].Value;
-            _logger.LogError(request, errorMsg);
-            return Result.Fail(new Error(errorMsg));
+            string message = "Returning empty enumerable of timeline items";
+            _logger.LogInformation(message);
+            return Result.Ok(Enumerable.Empty<TimelineItemDTO>());
         }
 
         return Result.Ok(_mapper.Map<IEnumerable<TimelineItemDTO>>(timelineItems));

--- a/Streetcode/Streetcode.BLL/MediatR/Toponyms/GetByStreetcodeId/GetToponymsByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Toponyms/GetByStreetcodeId/GetToponymsByStreetcodeIdHandler.cs
@@ -35,14 +35,15 @@ public class GetToponymsByStreetcodeIdHandler : IRequestHandler<GetToponymsByStr
                     .Include(sc => sc.Coordinate!));
         toponyms.DistinctBy(x => x.StreetName);
 
-        if (toponyms is null)
+        if (!toponyms.Any())
         {
-            string errorMsg = _stringLocalizerCannotFind["CannotFindAnyToponymByTheStreetcodeId", request.StreetcodeId].Value;
-            _logger.LogError(request, errorMsg);
-            return Result.Fail(new Error(errorMsg));
+            string message = "Returning empty enumerable of toponyms";
+            _logger.LogInformation(message);
+            return Result.Ok(Enumerable.Empty<ToponymDTO>());
         }
 
         var toponymDto = toponyms.GroupBy(x => x.StreetName).Select(group => group.First()).Select(x => _mapper.Map<ToponymDTO>(x));
+
         return Result.Ok(toponymDto);
     }
 }

--- a/Streetcode/Streetcode.WebApi/Properties/launchSettings.json
+++ b/Streetcode/Streetcode.WebApi/Properties/launchSettings.json
@@ -3,10 +3,7 @@
     "Streetcode_Local": {
       "commandName": "Project",
       "launchBrowser": false,
-      "environmentVariables": {
-        "STREETCODE_ENVIRONMENT": "Local",
-        "ASPNETCORE_ENVIRONMENT": "Local"
-      },
+      "ADMIN_PASSWORD": "Admin@1234",
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5000;https://localhost:5001"
     },

--- a/Streetcode/Streetcode.WebApi/Properties/launchSettings.json
+++ b/Streetcode/Streetcode.WebApi/Properties/launchSettings.json
@@ -3,7 +3,6 @@
     "Streetcode_Local": {
       "commandName": "Project",
       "launchBrowser": false,
-      "ADMIN_PASSWORD": "Admin@1234",
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5000;https://localhost:5001"
     },

--- a/Streetcode/Streetcode.WebApi/Properties/launchSettings.json
+++ b/Streetcode/Streetcode.WebApi/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "Streetcode_Local": {
       "commandName": "Project",
       "launchBrowser": false,
+      "environmentVariables": {
+        "STREETCODE_ENVIRONMENT": "Local",
+        "ASPNETCORE_ENVIRONMENT": "Local"
+      },
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5000;https://localhost:5001"
     },

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/AdditionalContent/AdditionalContentTests/TagTests/GetTagsByStreetcodeIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/AdditionalContent/AdditionalContentTests/TagTests/GetTagsByStreetcodeIdHandlerTests.cs
@@ -125,10 +125,10 @@ namespace Streetcode.XUnitTest.MediatRTests.AdditionalContent.TagTests
         public async Task Handler_Returns_Error()
         {
             // Arrange
-            var expectedError = $"Historycode id cannot be less than 1: {incorrect_streetcode_id}";
-            this.mockLocalizer.Setup(localizer => localizer["HistorycodeIdCannotBeLessThan1", incorrect_streetcode_id])
-                .Returns(new LocalizedString("HistorycodeIdCannotBeLessThan1", expectedError));
-
+             var expectedError = $"Cannot find any tag by the streetcode id: {streetcode_id}";
+            this.mockLocalizer.Setup(localizer => localizer["CannotFindAnyTagByTheStreetcodeId", streetcode_id])
+                .Returns(new LocalizedString("CannotFindAnyTagByTheStreetcodeId", expectedError));
+            
             var handler = new GetTagByStreetcodeIdHandler(this.mockRepo.Object, this.mockMapper.Object, this.mockLogger.Object, this.mockLocalizer.Object);
 
             // Act

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/AdditionalContent/AdditionalContentTests/TagTests/GetTagsByStreetcodeIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/AdditionalContent/AdditionalContentTests/TagTests/GetTagsByStreetcodeIdHandlerTests.cs
@@ -125,10 +125,10 @@ namespace Streetcode.XUnitTest.MediatRTests.AdditionalContent.TagTests
         public async Task Handler_Returns_Error()
         {
             // Arrange
-             var expectedError = $"Cannot find any tag by the streetcode id: {streetcode_id}";
-            this.mockLocalizer.Setup(localizer => localizer["CannotFindAnyTagByTheStreetcodeId", streetcode_id])
+            var expectedError = $"Cannot find any tag by the streetcode id: {incorrect_streetcode_id}";
+            this.mockLocalizer.Setup(localizer => localizer["CannotFindAnyTagByTheStreetcodeId", incorrect_streetcode_id])
                 .Returns(new LocalizedString("CannotFindAnyTagByTheStreetcodeId", expectedError));
-            
+
             var handler = new GetTagByStreetcodeIdHandler(this.mockRepo.Object, this.mockMapper.Object, this.mockLogger.Object, this.mockLocalizer.Object);
 
             // Act

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/GetByStreetCodeId/GetArtByStreetcodeIdTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/GetByStreetCodeId/GetArtByStreetcodeIdTest.cs
@@ -92,7 +92,7 @@ namespace Streetcode.XUnitTest.MediatRTests.Media.Arts
             // Arrange
             this.MockRepositoryAndMapper(new List<Art>(), new List<ArtDTO>());
             var handler = new GetArtsByStreetcodeIdHandler(this.mockRepo.Object, this.mockMapper.Object, this.blobService.Object, this.mockLogger.Object, this.mockLocalizer.Object);
-            var expectedError = $"Historycode id cannot be less than 1: {streetcodeId}";
+            var expectedError = $"Cannot find any art with corresponding streetcode id: {streetcodeId}";
 
             // Act
             var result = await handler.Handle(new GetArtsByStreetcodeIdQuery(streetcodeId), CancellationToken.None);
@@ -153,10 +153,10 @@ namespace Streetcode.XUnitTest.MediatRTests.Media.Arts
             {
                 if (args != null && args.Length > 0 && args[0] is int streetcodeId)
                 {
-                    return new LocalizedString(key, $"Historycode id cannot be less than 1: {streetcodeId}");
+                    return new LocalizedString(key, $"Cannot find any art with corresponding streetcode id: {streetcodeId}");
                 }
 
-                return new LocalizedString(key, "Historycode id cannot be less than 1");
+                return new LocalizedString(key, "Cannot find any art with corresponding streetcode id");
             });
         }
     }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/GetByStreetCodeId/GetArtByStreetcodeIdTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/GetByStreetCodeId/GetArtByStreetcodeIdTest.cs
@@ -4,6 +4,7 @@ using FluentResults;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.Localization;
 using Moq;
+using Streetcode.BLL.DTO.AdditionalContent.Tag;
 using Streetcode.BLL.DTO.Media.Art;
 using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.Interfaces.BlobStorage;
@@ -52,6 +53,25 @@ namespace Streetcode.XUnitTest.MediatRTests.Media.Arts
         [Theory]
         [InlineData(1)]
 
+        public async Task Handle_ReturnsEmptyArray(int streetcodeId)
+        {
+            // Arrange
+            this.MockRepositoryAndMapper(new List<Art>(), new List<ArtDTO>());
+            var handler = new GetArtsByStreetcodeIdHandler(this.mockRepo.Object, this.mockMapper.Object, this.blobService.Object, this.mockLogger.Object, this.mockLocalizer.Object);
+
+            // Act
+            var result = await handler.Handle(new GetArtsByStreetcodeIdQuery(streetcodeId), CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(
+                () => Assert.IsType<Result<IEnumerable<ArtDTO>>>(result),
+                () => Assert.IsAssignableFrom<IEnumerable<ArtDTO>>(result.Value),
+                () => Assert.Empty(result.Value));
+        }
+
+        [Theory]
+        [InlineData(1)]
+
         public async Task Handle_ReturnsType(int streetcodeId)
         {
             // Arrange
@@ -67,12 +87,12 @@ namespace Streetcode.XUnitTest.MediatRTests.Media.Arts
 
         [Theory]
         [InlineData(-1)]
-        public async Task Handle_WithNonExistentId_ReturnsError(int streetcodeId)
+        public async Task Handle_HistorycodeWithNonExistentId_ReturnsError(int streetcodeId)
         {
             // Arrange
             this.MockRepositoryAndMapper(new List<Art>(), new List<ArtDTO>());
             var handler = new GetArtsByStreetcodeIdHandler(this.mockRepo.Object, this.mockMapper.Object, this.blobService.Object, this.mockLogger.Object, this.mockLocalizer.Object);
-            var expectedError = $"Cannot find any art with corresponding streetcode id: {streetcodeId}";
+            var expectedError = $"Historycode id cannot be less than 1: {streetcodeId}";
 
             // Act
             var result = await handler.Handle(new GetArtsByStreetcodeIdQuery(streetcodeId), CancellationToken.None);
@@ -133,10 +153,10 @@ namespace Streetcode.XUnitTest.MediatRTests.Media.Arts
             {
                 if (args != null && args.Length > 0 && args[0] is int streetcodeId)
                 {
-                    return new LocalizedString(key, $"Cannot find any art with corresponding streetcode id: {streetcodeId}");
+                    return new LocalizedString(key, $"Historycode id cannot be less than 1: {streetcodeId}");
                 }
 
-                return new LocalizedString(key, "Cannot find an art with unknown streetcodeId");
+                return new LocalizedString(key, "Historycode id cannot be less than 1");
             });
         }
     }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Partners/GetParnerByStreetcodeIdTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Partners/GetParnerByStreetcodeIdTest.cs
@@ -112,7 +112,7 @@ public class GetParnerByStreetcodeIdTest
         {
             if (args != null && args.Length > 0 && args[0] is int)
             {
-                return new LocalizedString(key, $"Cannot find a partners by a streetcode id: {testStreetcodeContent.Id}";
+                return new LocalizedString(key, $"Cannot find a partners by a streetcode id: {testStreetcodeContent.Id}");
             }
 
             return new LocalizedString(key, "Cannot find any partners with unknown Id");

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Partners/GetParnerByStreetcodeIdTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Partners/GetParnerByStreetcodeIdTest.cs
@@ -107,15 +107,15 @@ public class GetParnerByStreetcodeIdTest
     {
         // Arrange
         var testStreetcodeContent = GetStreetcodeList()[0];
-        var expectedError = $"Cannot find any historycodes with corresponding historycode id: {testStreetcodeContent.Id}";
+        var expectedError = $"Cannot find a partners by a streetcode id: {testStreetcodeContent.Id}";
         this.mockLocalizerCannotFind.Setup(x => x[It.IsAny<string>(), It.IsAny<object>()]).Returns((string key, object[] args) =>
         {
             if (args != null && args.Length > 0 && args[0] is int)
             {
-                return new LocalizedString(key, $"Cannot find any historycodes with corresponding historycode id: {testStreetcodeContent.Id}");
+                return new LocalizedString(key, $"Cannot find a partners by a streetcode id: {testStreetcodeContent.Id}";
             }
 
-            return new LocalizedString(key, "Cannot find any historycodes with unknown id");
+            return new LocalizedString(key, "Cannot find any partners with unknown Id");
         });
         this.mockRepository.Setup(x => x.StreetcodeRepository
         .GetSingleOrDefaultAsync(

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Partners/GetParnerByStreetcodeIdTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Partners/GetParnerByStreetcodeIdTest.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using AutoMapper;
+using FluentResults;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.Localization;
 using Moq;
@@ -106,33 +107,21 @@ public class GetParnerByStreetcodeIdTest
     {
         // Arrange
         var testStreetcodeContent = GetStreetcodeList()[0];
-        var expectedError = $"Cannot find a partners by a streetcode id: {testStreetcodeContent.Id}";
+        var expectedError = $"Cannot find any historycodes with corresponding historycode id: {testStreetcodeContent.Id}";
         this.mockLocalizerCannotFind.Setup(x => x[It.IsAny<string>(), It.IsAny<object>()]).Returns((string key, object[] args) =>
         {
             if (args != null && args.Length > 0 && args[0] is int)
             {
-                return new LocalizedString(key, $"Cannot find a partners by a streetcode id: {testStreetcodeContent.Id}");
+                return new LocalizedString(key, $"Cannot find any historycodes with corresponding historycode id: {testStreetcodeContent.Id}");
             }
 
-            return new LocalizedString(key, "Cannot find any partners with unknown Id");
+            return new LocalizedString(key, "Cannot find any historycodes with unknown id");
         });
         this.mockRepository.Setup(x => x.StreetcodeRepository
         .GetSingleOrDefaultAsync(
             It.IsAny<Expression<Func<StreetcodeContent, bool>>>(),
             null))
-        .ReturnsAsync(testStreetcodeContent);
-
-        this.mockRepository.Setup(x => x.PartnersRepository
-            .GetAllAsync(
-                It.IsAny<Expression<Func<Partner, bool>>>(),
-                It.IsAny<Func<IQueryable<Partner>,
-                IIncludableQueryable<Partner, object>>>()))
-            .ReturnsAsync(GetPartnerListWithNotExistingStreetcodeId());
-
-        this.mockMapper
-            .Setup(x => x
-            .Map<IEnumerable<PartnerDTO>>(It.IsAny<IEnumerable<Partner>>()))
-            .Returns(GetPartnerDTOListWithNotExistingId());
+        .ReturnsAsync((StreetcodeContent?)null);
 
         var handler = new GetPartnersByStreetcodeIdHandler(this.mockMapper.Object, this.mockRepository.Object, this.mockLogger.Object, this.mockLocalizerCannotFind.Object);
 
@@ -143,6 +132,37 @@ public class GetParnerByStreetcodeIdTest
         Assert.Multiple(
             () => Assert.True(result.IsFailed),
             () => Assert.Equal(expectedError, result.Errors[0].Message));
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccessfully_EmptyList()
+    {
+        // Arrange
+        var testStreetcodeContent = GetStreetcodeList()[0];
+
+        this.mockRepository.Setup(x => x.StreetcodeRepository
+           .GetSingleOrDefaultAsync(
+               It.IsAny<Expression<Func<StreetcodeContent, bool>>>(),
+               null))
+           .ReturnsAsync(testStreetcodeContent);
+
+        this.mockRepository.Setup(x => x.PartnersRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Partner, bool>>>(),
+                It.IsAny<Func<IQueryable<Partner>,
+                IIncludableQueryable<Partner, object>>>()))
+            .ReturnsAsync(new List<Partner>());
+
+        var handler = new GetPartnersByStreetcodeIdHandler(this.mockMapper.Object, this.mockRepository.Object, this.mockLogger.Object, this.mockLocalizerCannotFind.Object);
+
+        // Act
+        var result = await handler.Handle(new GetPartnersByStreetcodeIdQuery(testStreetcodeContent.Id), CancellationToken.None);
+
+        // Asset
+        Assert.Multiple(
+                () => Assert.IsType<Result<IEnumerable<PartnerDTO>>>(result),
+                () => Assert.IsAssignableFrom<IEnumerable<PartnerDTO>>(result.Value),
+                () => Assert.Empty(result.Value));
     }
 
     private static IEnumerable<Partner> GetPartnerList()
@@ -170,16 +190,6 @@ public class GetParnerByStreetcodeIdTest
         };
 
         return streetCodes;
-    }
-
-    private static List<Partner> GetPartnerListWithNotExistingStreetcodeId()
-    {
-        return new List<Partner>();
-    }
-
-    private static List<PartnerDTO> GetPartnerDTOListWithNotExistingId()
-    {
-        return new List<PartnerDTO>();
     }
 
     private static List<PartnerDTO> GetPartnerDTOList()

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Timeline/TimelineItemTests/GetTimelineItemByStreetcodeIdTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Timeline/TimelineItemTests/GetTimelineItemByStreetcodeIdTest.cs
@@ -1,0 +1,121 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using AutoMapper;
+using FluentResults;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.Localization;
+using Moq;
+using Streetcode.BLL.DTO.Timeline;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Timeline.TimelineItem.GetByStreetcodeId;
+using Streetcode.BLL.SharedResource;
+using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Entities.Streetcode.TextContent;
+using Streetcode.DAL.Entities.Timeline;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+
+namespace Streetcode.XUnitTest.MediatRTests.Timeline.TimelineItemTests
+{
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1413:UseTrailingCommasInMultiLineInitializers", Justification = "Reviewed.")]
+    public class GetTimelineItemByStreetcodeIdTest
+    {
+        private readonly Mock<IRepositoryWrapper> mockRepository;
+        private readonly Mock<IMapper> mockMapper;
+        private readonly Mock<ILoggerService> mockLogger;
+        private readonly Mock<IStringLocalizer<CannotFindSharedResource>> mockLocalizerCannotFind;
+
+        public GetTimelineItemByStreetcodeIdTest()
+        {
+            mockRepository = new Mock<IRepositoryWrapper>();
+            mockMapper = new Mock<IMapper>();
+            mockLogger = new Mock<ILoggerService>();
+            mockLocalizerCannotFind = new Mock<IStringLocalizer<CannotFindSharedResource>>();
+        }
+
+        [Fact]
+        public async Task ReturnsSuccessfully_NotEmpty()
+        {
+            // Arrange
+            this.mockRepository.Setup(x => x.TimelineRepository.GetAllAsync(
+                It.IsAny<Expression<Func<TimelineItem, bool>>>(),
+                It.IsAny<Func<IQueryable<TimelineItem>,
+                IIncludableQueryable<TimelineItem, object>>>()))
+                .ReturnsAsync(GetExistingTimelineList());
+
+            this.mockMapper
+            .Setup(x => x
+            .Map<IEnumerable<TimelineItemDTO>>(It.IsAny<IEnumerable<TimelineItem>>()))
+            .Returns(GetTimelineItemDTOList());
+
+            var handler = new GetTimelineItemsByStreetcodeIdHandler(this.mockRepository.Object, this.mockMapper.Object, this.mockLogger.Object, this.mockLocalizerCannotFind.Object);
+            int streetcodeId = 1;
+
+            // Act
+            var result = await handler.Handle(new GetTimelineItemsByStreetcodeIdQuery(streetcodeId), CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(
+            () => Assert.NotNull(result),
+            () => Assert.True(result.IsSuccess),
+            () => Assert.NotEmpty(result.Value));
+        }
+
+        [Fact]
+        public async Task ReturnsSuccessfully_Empty()
+        {
+            // Arrange
+            this.mockRepository.Setup(x => x.TimelineRepository.GetAllAsync(
+                It.IsAny<Expression<Func<TimelineItem, bool>>>(),
+                It.IsAny<Func<IQueryable<TimelineItem>,
+                IIncludableQueryable<TimelineItem, object>>>()))
+                .ReturnsAsync(GetEmptyTimelineList());
+
+            var handler = new GetTimelineItemsByStreetcodeIdHandler(this.mockRepository.Object, this.mockMapper.Object, this.mockLogger.Object, this.mockLocalizerCannotFind.Object);
+            int streetcodeId = 1;
+
+            // Act
+            var result = await handler.Handle(new GetTimelineItemsByStreetcodeIdQuery(streetcodeId), CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(
+                () => Assert.IsType<Result<IEnumerable<TimelineItemDTO>>>(result),
+                () => Assert.IsAssignableFrom<IEnumerable<TimelineItemDTO>>(result.Value),
+                () => Assert.Empty(result.Value));
+        }
+
+        public static List<TimelineItem> GetExistingTimelineList()
+        {
+            return new List<TimelineItem> {
+                new TimelineItem
+                {
+                    Id = 1,
+                    Date = DateTime.Now,
+                    DateViewPattern = DAL.Enums.DateViewPattern.DateMonthYear,
+                    Streetcode = new StreetcodeContent
+                    {
+                        Id = 1,
+                    }
+                }
+            };
+        }
+
+        public static List<TimelineItem> GetEmptyTimelineList()
+        {
+            return new List<TimelineItem>();
+        }
+
+        public static List<TimelineItemDTO> GetTimelineItemDTOList()
+        {
+            return new List<TimelineItemDTO>
+            {
+                new TimelineItemDTO
+                {
+                    Id = 1,
+                    Date = DateTime.Now,
+                    DateViewPattern = DAL.Enums.DateViewPattern.DateMonthYear,
+                }
+            };
+        }
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Toponyms/GetToponymsByStreetcodeIdTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Toponyms/GetToponymsByStreetcodeIdTest.cs
@@ -1,0 +1,111 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using AutoMapper;
+using FluentResults;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.Localization;
+using Moq;
+using Streetcode.BLL.DTO.Toponyms;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Toponyms.GetByStreetcodeId;
+using Streetcode.BLL.SharedResource;
+using Streetcode.DAL.Entities.Toponyms;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+
+namespace Streetcode.XUnitTest.MediatRTests.Toponyms
+{
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1413:UseTrailingCommasInMultiLineInitializers", Justification = "Reviewed.")]
+    public class GetToponymsByStreetcodeIdTest
+    {
+        private readonly Mock<IRepositoryWrapper> mockRepository;
+        private readonly Mock<IMapper> mockMapper;
+        private readonly Mock<ILoggerService> mockLogger;
+        private readonly Mock<IStringLocalizer<CannotFindSharedResource>> mockLocalizerCannotFind;
+
+        public GetToponymsByStreetcodeIdTest()
+        {
+            mockRepository = new Mock<IRepositoryWrapper>();
+            mockMapper = new Mock<IMapper>();
+            mockLogger = new Mock<ILoggerService>();
+            mockLocalizerCannotFind = new Mock<IStringLocalizer<CannotFindSharedResource>>();
+        }
+
+        [Fact]
+        public async Task ReturnsSuccessfully_NotEmpty()
+        {
+            // Arrange
+            this.mockRepository.Setup(x => x.ToponymRepository.GetAllAsync(
+                It.IsAny<Expression<Func<Toponym, bool>>>(),
+                It.IsAny<Func<IQueryable<Toponym>,
+                IIncludableQueryable<Toponym, object>>>()
+                )).ReturnsAsync(GetExistingToponymList());
+
+            this.mockMapper.Setup(x => x
+            .Map<IEnumerable<ToponymDTO>>(It.IsAny<IEnumerable<Toponym>>()))
+            .Returns(GetToponymDTOList());
+
+            int streetcodeId = 1;
+            var handler = new GetToponymsByStreetcodeIdHandler(this.mockRepository.Object, this.mockMapper.Object, this.mockLogger.Object, this.mockLocalizerCannotFind.Object);
+
+            // Act
+            var result = await handler.Handle(new GetToponymsByStreetcodeIdQuery(streetcodeId), CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(
+            () => Assert.NotNull(result),
+            () => Assert.True(result.IsSuccess),
+            () => Assert.NotEmpty(result.Value));
+        }
+
+        [Fact]
+        public async Task ReturnsSuccessfully_Empty()
+        {
+            // Arrange
+            this.mockRepository.Setup(x => x.ToponymRepository.GetAllAsync(
+                It.IsAny<Expression<Func<Toponym, bool>>>(),
+                It.IsAny<Func<IQueryable<Toponym>,
+                IIncludableQueryable<Toponym, object>>>()
+                )).ReturnsAsync(GetEmptyToponymList());
+
+            int streetcodeId = 1;
+            var handler = new GetToponymsByStreetcodeIdHandler(this.mockRepository.Object, this.mockMapper.Object, this.mockLogger.Object, this.mockLocalizerCannotFind.Object);
+
+            // Act
+            var result = await handler.Handle(new GetToponymsByStreetcodeIdQuery(streetcodeId), CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(
+               () => Assert.IsType<Result<IEnumerable<ToponymDTO>>>(result),
+               () => Assert.IsAssignableFrom<IEnumerable<ToponymDTO>>(result.Value),
+               () => Assert.Empty(result.Value));
+        }
+
+        public static List<Toponym> GetExistingToponymList()
+        {
+            return new List<Toponym>() {
+                new Toponym
+                {
+                    Id = 1,
+                    Oblast = "Test oblast",
+                    StreetName = "Test street"
+                }
+            };
+        }
+
+        public static List<ToponymDTO> GetToponymDTOList() {
+            return new List<ToponymDTO> {
+                new ToponymDTO
+                {
+                    Id = 1,
+                    Oblast = "Test oblast",
+                    StreetName = "Test street"
+                }
+            };
+        }
+        public static List<Toponym> GetEmptyToponymList()
+        {
+            return new List<Toponym>();
+        }
+    }
+}


### PR DESCRIPTION
## GitHub

* [Main GitHub ticket](https://github.com/ita-social-projects/StreetCode/issues/1924)

## Summary of issue

It was found in https://github.com/ita-social-projects/StreetCode/issues/1811#issue-2609849048 that the full screen error warning was caused by the lack of error handling in many fragments (for example, with toponyms).

## Summary of change

Changed mediatr behavior to return successful result with empty array value rather then returning bad request.
