### PR TITLE
Feature/issue 2014

### DIFF
--- a/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToValidateSharedResource.en-US.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToValidateSharedResource.en-US.Designer.cs
@@ -123,6 +123,15 @@ namespace Streetcode.BLL.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The image size can&apos;t exceed {0} MB.
+        /// </summary>
+        internal static string ImageSizeExceeded {
+            get {
+                return ResourceManager.GetString("ImageSizeExceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Field &apos;{0}&apos; is invalid.
         /// </summary>
         internal static string Invalid {
@@ -168,7 +177,7 @@ namespace Streetcode.BLL.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Logo must match corresponding url.
+        ///   Looks up a localized string similar to The link does not match the selected social network.
         /// </summary>
         internal static string LogoMustMatchUrl {
             get {

--- a/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToValidateSharedResource.en-US.resx
+++ b/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToValidateSharedResource.en-US.resx
@@ -186,4 +186,7 @@
   <data name="EventStreetcodeCannotHasFirstName" xml:space="preserve">
     <value>The streetcode of type 'Event' cannot has 'First name' and 'Last name'</value>
   </data>
+  <data name="ImageSizeExceeded" xml:space="preserve">
+    <value>The image size can't exceed {0} MB</value>
+  </data>
 </root>

--- a/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToValidateSharedResource.uk-UA.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToValidateSharedResource.uk-UA.Designer.cs
@@ -123,6 +123,15 @@ namespace Streetcode.BLL.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Розмір картинки не може перевищувати {0} MB.
+        /// </summary>
+        internal static string ImageSizeExceeded {
+            get {
+                return ResourceManager.GetString("ImageSizeExceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Поле &apos;{0}&apos; має недійсне значення.
         /// </summary>
         internal static string Invalid {
@@ -168,7 +177,7 @@ namespace Streetcode.BLL.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Логотип має відповідати посиланню.
+        ///   Looks up a localized string similar to Посилання не співпадає з обраною соціальною мережою.
         /// </summary>
         internal static string LogoMustMatchUrl {
             get {

--- a/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToValidateSharedResource.uk-UA.resx
+++ b/Streetcode/Streetcode.BLL/Resources/SharedResource.FailedToValidateSharedResource.uk-UA.resx
@@ -186,4 +186,7 @@
   <data name="EventStreetcodeCannotHasFirstName" xml:space="preserve">
     <value>Стріткод типу 'Подія' не може мати поля 'Ім'я' та 'Прізвище' </value>
   </data>
+  <data name="ImageSizeExceeded" xml:space="preserve">
+    <value>Розмір картинки не може перевищувати {0} MB</value>
+  </data>
 </root>

--- a/Streetcode/Streetcode.BLL/Validators/Media/Image/BaseImageValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Media/Image/BaseImageValidator.cs
@@ -13,6 +13,7 @@ public class BaseImageValidator : AbstractValidator<ImageFileBaseCreateDTO>
     public const int MaxTitleLength = 100;
     public const int MaxAltLength = 300;
     public const int MaxMimeTypeLength = 10;
+    public const int MaxImageSizeInMb = 3;
 
     public readonly List<string> Extensions = new() { "png", "jpeg", "jpg", "webp" };
     public readonly List<string> MimeTypes = new() { "image/jpeg", "image/png", "image/webp" };
@@ -31,7 +32,8 @@ public class BaseImageValidator : AbstractValidator<ImageFileBaseCreateDTO>
             .WithMessage(localizer["MaxLength", fieldLocalizer["Alt"], MaxAltLength]);
 
         RuleFor(dto => dto.BaseFormat)
-            .NotEmpty().WithMessage(localizer["IsRequired", fieldLocalizer["BaseFormat"]]);
+            .NotEmpty().WithMessage(localizer["IsRequired", fieldLocalizer["BaseFormat"]])
+            .Must(IsImageSizeValid).WithMessage(localizer["ImageSizeExceeded", MaxImageSizeInMb]);
 
         RuleFor(dto => dto.MimeType)
             .NotEmpty().WithMessage(localizer["IsRequired", fieldLocalizer["MimeType"]])
@@ -43,5 +45,14 @@ public class BaseImageValidator : AbstractValidator<ImageFileBaseCreateDTO>
             .NotEmpty().WithMessage(localizer["IsRequired", fieldLocalizer["Extension"]])
             .Must(x => Extensions.Contains(x.ToLower()))
             .WithMessage(localizer["MustBeOneOf", fieldLocalizer["Extension"], ValidationExtentions.ConcatWithComma(Extensions)]);
+    }
+
+    private bool IsImageSizeValid(string baseFormat)
+    {
+        int paddingCount = baseFormat.EndsWith("==") ? 2 :
+            baseFormat.EndsWith("=") ? 1 : 0;
+        int sizeInBytes = (baseFormat.Length * 3 / 4) - paddingCount;
+        int maxFileSizeInBytes = MaxImageSizeInMb * 1024 * 1024;
+        return sizeInBytes <= maxFileSizeInBytes;
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/Mocks/MockFailedToValidateLocalizer.cs
+++ b/Streetcode/Streetcode.XUnitTest/Mocks/MockFailedToValidateLocalizer.cs
@@ -34,6 +34,7 @@ public class MockFailedToValidateLocalizer : IStringLocalizer<FailedToValidateSh
             "MustContainExactlyOneAlt1",
             "MustContainAtMostOneAlt0",
             "MustContainAtMostOneAlt2",
+            "ImageSizeExceeded",
         });
 
         this.groupedErrors.Add(2, new List<string>()


### PR DESCRIPTION
dev
## JIRA

* [2014](https://github.com/ita-social-projects/StreetCode/issues/2014)
* [2043](https://github.com/ita-social-projects/StreetCode/issues/2043)

## Summary of issue

The problem was that there was no backend validation for the image size. This allowed files that exceeded the allowed size to pass through without restriction

## Summary of change

Added backend validation in the DTO using FluentValidation to enforce restrictions on the image size using its base64 representation

