### PR TITLE
Fixed bug with possibility to create streetcodes with the same art indexes

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
@@ -280,6 +280,17 @@ public class CreateStreetcodeHandler : IRequestHandler<CreateStreetcodeCommand, 
             return;
         }
 
+        var artUniqueIds = artSlidesList
+            .SelectMany(slide => slide.StreetcodeArts)
+            .Select(art => art.Index)
+            .Distinct()
+            .ToList();
+
+        if (artUniqueIds.Count != artsList.Count)
+        {
+            throw new ArgumentException(_stringLocalizerFailedToValidate["Індекс картинки має бути унікальним"], nameof(artSlides));
+        }
+
         var usedArtIds = new HashSet<int>(artSlidesList
             .SelectMany(slide => slide.StreetcodeArts)
             .Select(streetcodeArt => streetcodeArt.ArtId));

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
@@ -288,7 +288,7 @@ public class CreateStreetcodeHandler : IRequestHandler<CreateStreetcodeCommand, 
 
         if (artUniqueIds.Count != artsList.Count)
         {
-            throw new ArgumentException(_stringLocalizerFailedToValidate["Індекс картинки має бути унікальним"], nameof(artSlides));
+            throw new ArgumentException(_stringLocalizerFailedToValidate["MustBeUnique", _stringLocalizerFieldNames["Index"]], nameof(artSlides));
         }
 
         var usedArtIds = new HashSet<int>(artSlidesList


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Summary of issue

Same image Index could be used within one slide

## Summary of change

Fixed bug with possibility to create streetcodes with the same art indexes

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to ensure that image indices in art galleries are unique, preventing duplicate index values when adding art slides. Users will now receive an error message if duplicate indices are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->