### PR TITLE
Fixed bug when we could create history code with amount of art slides…

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
@@ -23,6 +23,7 @@ using Streetcode.DAL.Entities.Media.Images;
 using Streetcode.DAL.Entities.Partners;
 using Streetcode.DAL.Entities.Streetcode;
 using Streetcode.DAL.Entities.Timeline;
+using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using TransactionLinkEntity = Streetcode.DAL.Entities.Transactions.TransactionLink;
 
@@ -286,9 +287,15 @@ public class CreateStreetcodeHandler : IRequestHandler<CreateStreetcodeCommand, 
             .Distinct()
             .ToList();
 
-        if (artUniqueIds.Count != artsList.Count)
+        if (artUniqueIds.Count != artSlidesList.SelectMany(slide => slide.StreetcodeArts).Count())
         {
             throw new ArgumentException(_stringLocalizerFailedToValidate["MustBeUnique", _stringLocalizerFieldNames["Index"]], nameof(artSlides));
+        }
+
+        if (artSlidesList.Any(artSlide => artSlidesList.SelectMany(slide => slide.StreetcodeArts).Count() !=
+                                          StreetcodeArtSlideTemplateConsts.CountOfArtsInTemplateDictionary[artSlide.Template]))
+        {
+            throw new ArgumentException(_stringLocalizerFailedToValidate["SizeMustBeTheSameAsInTemplate", _stringLocalizerFieldNames["CountOfArts"]], nameof(artSlides));
         }
 
         var usedArtIds = new HashSet<int>(artSlidesList

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
@@ -292,7 +292,9 @@ public class CreateStreetcodeHandler : IRequestHandler<CreateStreetcodeCommand, 
             throw new ArgumentException(_stringLocalizerFailedToValidate["MustBeUnique", _stringLocalizerFieldNames["Index"]], nameof(artSlides));
         }
 
-        if (artSlidesList.Any(artSlide => artSlidesList.SelectMany(slide => slide.StreetcodeArts).Count() !=
+        int amountOfArts = artSlidesList.SelectMany(slide => slide.StreetcodeArts).Count();
+
+        if (artSlidesList.Any(artSlide => amountOfArts !=
                                           StreetcodeArtSlideTemplateConsts.CountOfArtsInTemplateDictionary[artSlide.Template]))
         {
             throw new ArgumentException(_stringLocalizerFailedToValidate["SizeMustBeTheSameAsInTemplate", _stringLocalizerFieldNames["CountOfArts"]], nameof(artSlides));

--- a/Streetcode/Streetcode.DAL/Enums/StreetcodeArtSlideTemplate.cs
+++ b/Streetcode/Streetcode.DAL/Enums/StreetcodeArtSlideTemplate.cs
@@ -2,18 +2,39 @@ namespace Streetcode.DAL.Enums;
 
 public enum StreetcodeArtSlideTemplate
 {
-    OneToFourAndFiveToSix = 0,
-    OneToTwoAndThreeToFourAndFiveToSix = 1,
-    OneAndTwoAndThreeAndFourAndFiveAndSix = 2,
-    OneToFour = 3,
-    OneToTwo = 4,
-    OneToTwoAndThreeToFour = 5,
-    OneToFourAndFiveAndSix = 6,
+    OneToTwo = 0,
+    OneToTwoAndThreeToFour = 1,
+    OneToFour = 2,
+    OneToFourAndFiveToSix = 3,
+    OneToTwoAndThreeToFourAndFiveToSix = 4,
+    OneToFourAndFiveAndSix = 5,
+    OneToTwoAndThreeToFourAndFive = 6,
     OneAndTwoAndThreeToFour = 7,
     OneAndTwoAndThreeAndFour = 8,
-    OneToTwoAndThreeToFourAndFive = 9,
+    OneAndTwoAndThreeToFourAndFive = 9,
     OneAndTwoAndThreeToFourAndFiveToSix = 10,
-    OneAndTwoAndThreeToFourAndFive = 11,
+    OneAndTwoAndThreeAndFourAndFive = 11,
     OneAndTwoAndThreeToFourAndFiveAndSix = 12,
-    OneAndTwoAndThreeAndFourAndFive = 13,
+    OneAndTwoAndThreeAndFourAndFiveAndSix = 13,
+}
+
+public static class StreetcodeArtSlideTemplateConsts
+{
+    public static Dictionary<StreetcodeArtSlideTemplate, int> CountOfArtsInTemplateDictionary = new()
+        {
+            { StreetcodeArtSlideTemplate.OneToFour, 1 },
+            { StreetcodeArtSlideTemplate.OneToTwo, 1 },
+            { StreetcodeArtSlideTemplate.OneToFourAndFiveToSix, 2 },
+            { StreetcodeArtSlideTemplate.OneToTwoAndThreeToFour, 2 },
+            { StreetcodeArtSlideTemplate.OneToTwoAndThreeToFourAndFiveToSix, 3 },
+            { StreetcodeArtSlideTemplate.OneToFourAndFiveAndSix, 3 },
+            { StreetcodeArtSlideTemplate.OneAndTwoAndThreeToFour, 3 },
+            { StreetcodeArtSlideTemplate.OneToTwoAndThreeToFourAndFive, 3 },
+            { StreetcodeArtSlideTemplate.OneAndTwoAndThreeAndFour, 4 },
+            { StreetcodeArtSlideTemplate.OneAndTwoAndThreeToFourAndFiveToSix, 4 },
+            { StreetcodeArtSlideTemplate.OneAndTwoAndThreeToFourAndFive, 4 },
+            { StreetcodeArtSlideTemplate.OneAndTwoAndThreeToFourAndFiveAndSix, 5 },
+            { StreetcodeArtSlideTemplate.OneAndTwoAndThreeAndFourAndFive, 5 },
+            { StreetcodeArtSlideTemplate.OneAndTwoAndThreeAndFourAndFiveAndSix, 6 },
+        };
 }


### PR DESCRIPTION
… that isn't equal to the amount in template

dev

## Summary of issue

We could create history code when amount of art slides is more or less than in the template

## Summary of change

Added new validation for this case

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced validation to ensure each art slide contains the exact number of arts required by its template.

- **Bug Fixes**
  - Improved uniqueness validation for art entries within galleries.

- **Refactor**
  - Updated and renamed art slide template options for clarity and consistency.
  - Provided a centralized reference for the number of arts required per template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->