### PR TITLE
Fixed indexes

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
@@ -297,7 +297,7 @@ public class CreateStreetcodeHandler : IRequestHandler<CreateStreetcodeCommand, 
         if (artSlidesList.Any(artSlide => amountOfArts !=
                                           StreetcodeArtSlideTemplateConsts.CountOfArtsInTemplateDictionary[artSlide.Template]))
         {
-            throw new ArgumentException(_stringLocalizerFailedToValidate["SizeMustBeTheSameAsInTemplate", _stringLocalizerFieldNames["CountOfArts"]], nameof(artSlides));
+            throw new ArgumentException(_stringLocalizerFailedToValidate["AmountMustBeTheSameAsInTemplate", _stringLocalizerFieldNames["CountOfArts"]], nameof(artSlides));
         }
 
         var existingArtIds = (await _repositoryWrapper.StreetcodeArtRepository

--- a/Streetcode/Streetcode.DAL/Enums/StreetcodeArtSlideTemplate.cs
+++ b/Streetcode/Streetcode.DAL/Enums/StreetcodeArtSlideTemplate.cs
@@ -2,20 +2,20 @@ namespace Streetcode.DAL.Enums;
 
 public enum StreetcodeArtSlideTemplate
 {
-    OneToTwo = 0,
-    OneToTwoAndThreeToFour = 1,
-    OneToFour = 2,
-    OneToFourAndFiveToSix = 3,
-    OneToTwoAndThreeToFourAndFiveToSix = 4,
-    OneToFourAndFiveAndSix = 5,
-    OneToTwoAndThreeToFourAndFive = 6,
+    OneToFourAndFiveToSix = 0,
+    OneToTwoAndThreeToFourAndFiveToSix = 1,
+    OneAndTwoAndThreeAndFourAndFiveAndSix = 2,
+    OneToFour = 3,
+    OneToTwo = 4,
+    OneToTwoAndThreeToFour = 5,
+    OneToFourAndFiveAndSix = 6,
     OneAndTwoAndThreeToFour = 7,
     OneAndTwoAndThreeAndFour = 8,
-    OneAndTwoAndThreeToFourAndFive = 9,
+    OneToTwoAndThreeToFourAndFive = 9,
     OneAndTwoAndThreeToFourAndFiveToSix = 10,
-    OneAndTwoAndThreeAndFourAndFive = 11,
+    OneAndTwoAndThreeToFourAndFive = 11,
     OneAndTwoAndThreeToFourAndFiveAndSix = 12,
-    OneAndTwoAndThreeAndFourAndFiveAndSix = 13,
+    OneAndTwoAndThreeAndFourAndFive = 13,
 }
 
 public static class StreetcodeArtSlideTemplateConsts


### PR DESCRIPTION
dev

## Summary of issue

We couldn't create streetcode with art galerry due to wrong amount of images in slides

## Summary of change

Fixed template indexes

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the validation error message for art slide counts to improve clarity.

- **Refactor**
  - Reordered and renamed art slide template options for improved consistency and clarity in selection menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->